### PR TITLE
expand cakephp version lower limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.6.0",
         "ext-json": "*",
-        "cakephp/cakephp": "~3.5",
+        "cakephp/cakephp": "~3.4",
         "sendgrid/sendgrid": "^7.3"
     },
     "autoload": {


### PR DESCRIPTION
hi. Im sorry for my broken english.

we are using cakephp 3.4.
but, new version of this great product require version 3.5 over.
therefore, i tried using source code of version 2.0.0-beta3 in us environment. as a result, it worked perfect.

i think, there is no difference in cakephp email functions between 3.4 to 3.5.
https://book.cakephp.org/3/en/appendices/3-5-migration-guide.html

Id like this great and useable product to support cakephp 3.4.
