### PR TITLE
Add support for email address that have illegal local part

### DIFF
--- a/src/Mailer/Transport/SendgridTransport.php
+++ b/src/Mailer/Transport/SendgridTransport.php
@@ -129,10 +129,10 @@ class SendgridTransport extends AbstractTransport
      * @param array $raw_array Array with email as key, name as value
      * @return array $array
      */
-    protected function _wrapIllegalLocalPartInDoubleQuote(array $raw_array): array
+    protected function _wrapIllegalLocalPartInDoubleQuote(array $rawArray): array
     {
         $array = [];
-        foreach ($raw_array as $mail => $name) {
+        foreach ($rawArray as $mail => $name) {
             if (preg_match('/^(\.[^@]*|(?=[^@]*\.{2,})[^@]*|[^@]*\.)@.*$/', $mail)) {
                 $mail = preg_replace('/([^@]+)(@.*)$/', '"$1"$2', $mail);
             }

--- a/src/Mailer/Transport/SendgridTransport.php
+++ b/src/Mailer/Transport/SendgridTransport.php
@@ -46,14 +46,14 @@ class SendgridTransport extends AbstractTransport
         $sendgridMail->setFrom(key($email->getFrom()), current($email->getFrom()));
         $sendgridMail->setSubject($email->getOriginalSubject());
 
-        $sendgridMail->addTos($email->getTo());
+        $sendgridMail->addTos($this->_wrapIllegalLocalPartInDoubleQuote($email->getTo()));
 
         if (!empty($email->getCc())) {
-            $sendgridMail->addCcs($email->getCc());
+            $sendgridMail->addCcs($this->_wrapIllegalLocalPartInDoubleQuote($email->getCc()));
         }
 
         if (!empty($email->getBcc())) {
-            $sendgridMail->addBccs($email->getBcc());
+            $sendgridMail->addBccs($this->_wrapIllegalLocalPartInDoubleQuote($email->getBcc()));
         }
 
         $sendgridMail->setReplyTo($email->getReplyTo() ? key($email->getReplyTo()) : key($email->getFrom()));
@@ -121,5 +121,24 @@ class SendgridTransport extends AbstractTransport
         }
 
         return $attachments;
+    }
+
+    /**
+     * Wrap illegal local part in double quote
+     *
+     * @param array $raw_array
+     *   Array with email as key, name as value
+     * @return array $array
+     */
+    protected function _wrapIllegalLocalPartInDoubleQuote(array $raw_array): array
+    {
+        $array = [];
+        foreach($raw_array as $mail => $name) {
+            if (preg_match("/^(\.[^@]*|(?=[^@]*\.{2,})[^@]*|[^@]*\.)@.*$/", $mail)) {
+                $mail = preg_replace("/([^@]+)(@.*)$/", '"$1"$2', $mail);
+            }
+            $array[$mail] = $name;
+        }
+        return $array;
     }
 }

--- a/src/Mailer/Transport/SendgridTransport.php
+++ b/src/Mailer/Transport/SendgridTransport.php
@@ -126,19 +126,19 @@ class SendgridTransport extends AbstractTransport
     /**
      * Wrap illegal local part in double quote
      *
-     * @param array $raw_array
-     *   Array with email as key, name as value
+     * @param array $raw_array Array with email as key, name as value
      * @return array $array
      */
     protected function _wrapIllegalLocalPartInDoubleQuote(array $raw_array): array
     {
         $array = [];
-        foreach($raw_array as $mail => $name) {
-            if (preg_match("/^(\.[^@]*|(?=[^@]*\.{2,})[^@]*|[^@]*\.)@.*$/", $mail)) {
-                $mail = preg_replace("/([^@]+)(@.*)$/", '"$1"$2', $mail);
+        foreach ($raw_array as $mail => $name) {
+            if (preg_match('/^(\.[^@]*|(?=[^@]*\.{2,})[^@]*|[^@]*\.)@.*$/', $mail)) {
+                $mail = preg_replace('/([^@]+)(@.*)$/', '"$1"$2', $mail);
             }
             $array[$mail] = $name;
         }
+
         return $array;
     }
 }

--- a/src/Mailer/Transport/SendgridTransport.php
+++ b/src/Mailer/Transport/SendgridTransport.php
@@ -126,7 +126,7 @@ class SendgridTransport extends AbstractTransport
     /**
      * Wrap illegal local part in double quote
      *
-     * @param array $raw_array Array with email as key, name as value
+     * @param array $rawArray Array with email as key, name as value
      * @return array $array
      */
     protected function _wrapIllegalLocalPartInDoubleQuote(array $rawArray): array


### PR DESCRIPTION
need wrapping local part in double quote for it send email that have illegal local part with using sendgrid.

I could only find Japanese document. sorry. :pray: 
https://support.sendgrid.kke.co.jp/hc/ja/articles/360000019762

I confirmed supported this format by `sendgrid/sendgrid` latest version ( https://packagist.org/packages/sendgrid/sendgrid#7.9.2 )

Also, I tested in CakePHP 4.2 .