### PR TITLE
Fixed PHP 8 errors about types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "source": "https://github.com/Iandenh/cakephp-sendgrid"
     },
     "require": {
+        "php": ">=8.1",
         "ext-json": "*",
         "cakephp/cakephp": "^5.0",
         "sendgrid/sendgrid": "^7.3 || ^8"

--- a/src/Mailer/Transport/SendgridTransport.php
+++ b/src/Mailer/Transport/SendgridTransport.php
@@ -27,7 +27,7 @@ class SendgridTransport extends AbstractTransport
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'api_key' => null,
         'click_tracking' => true,
         'open_tracking' => true,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,19 +19,19 @@ class Plugin extends BasePlugin
      *
      * @var bool
      */
-    protected $routesEnabled = false;
+    protected bool $routesEnabled = false;
 
     /**
      * Enable middleware
      *
      * @var bool
      */
-    protected $middlewareEnabled = false;
+    protected bool $middlewareEnabled = false;
 
     /**
      * Console middleware
      *
      * @var bool
      */
-    protected $consoleEnabled = false;
+    protected bool $consoleEnabled = false;
 }


### PR DESCRIPTION
Added php version requirement >= 8.1 as CakePHP 5 requires that
Added types for class constants so they are compatible with their parent class